### PR TITLE
docs: fix API bug with older versions

### DIFF
--- a/versioned_docs/version-v0.2.23/api-deprecated/llama-stack-specification-deprecated-apis.md
+++ b/versioned_docs/version-v0.2.23/api-deprecated/llama-stack-specification-deprecated-apis.md
@@ -1,0 +1,3 @@
+# Deprecated APIs
+
+For deprecated APIs in this version, please refer to the [main API documentation](../api/llama-stack-specification).

--- a/versioned_docs/version-v0.2.23/api-experimental/llama-stack-specification-experimental-apis.md
+++ b/versioned_docs/version-v0.2.23/api-experimental/llama-stack-specification-experimental-apis.md
@@ -1,0 +1,3 @@
+# Experimental APIs
+
+For experimental APIs in this version, please refer to the [main API documentation](../api/llama-stack-specification).

--- a/versioned_sidebars/version-v0.2.23-sidebars.json
+++ b/versioned_sidebars/version-v0.2.23-sidebars.json
@@ -1368,6 +1368,16 @@
       ]
     }
   ],
-  "experimentalApiSidebar": [],
-  "deprecatedApiSidebar": []
+  "experimentalApiSidebar": [
+    {
+      "type": "doc",
+      "id": "api-experimental/llama-stack-specification-experimental-apis"
+    }
+  ],
+  "deprecatedApiSidebar": [
+    {
+      "type": "doc",
+      "id": "api-deprecated/llama-stack-specification-deprecated-apis"
+    }
+  ]
 }

--- a/versioned_sidebars/version-v0.2.23-sidebars.json
+++ b/versioned_sidebars/version-v0.2.23-sidebars.json
@@ -1367,5 +1367,17 @@
         }
       ]
     }
+  ],
+  "experimentalApiSidebar": [
+    {
+      "type": "doc",
+      "id": "api-experimental/llama-stack-specification-experimental-apis"
+    }
+  ],
+  "deprecatedApiSidebar": [
+    {
+      "type": "doc",
+      "id": "api-deprecated/llama-stack-specification-deprecated-apis"
+    }
   ]
 }

--- a/versioned_sidebars/version-v0.2.23-sidebars.json
+++ b/versioned_sidebars/version-v0.2.23-sidebars.json
@@ -1367,17 +1367,5 @@
         }
       ]
     }
-  ],
-  "experimentalApiSidebar": [
-    {
-      "type": "doc",
-      "id": "api-experimental/llama-stack-specification-experimental-apis"
-    }
-  ],
-  "deprecatedApiSidebar": [
-    {
-      "type": "doc",
-      "id": "api-deprecated/llama-stack-specification-deprecated-apis"
-    }
   ]
 }

--- a/versioned_sidebars/version-v0.2.23-sidebars.json
+++ b/versioned_sidebars/version-v0.2.23-sidebars.json
@@ -322,7 +322,7 @@
       ]
     }
   ],
-  "apiSidebar": [
+  "stableApiSidebar": [
     {
       "type": "doc",
       "id": "api/llama-stack-specification"
@@ -1367,5 +1367,7 @@
         }
       ]
     }
-  ]
+  ],
+  "experimentalApiSidebar": [],
+  "deprecatedApiSidebar": []
 }


### PR DESCRIPTION
Fixes a breaking bug with older documentation versions (pre-split)